### PR TITLE
Update proficiency section with badge images

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
   <br/>
 <h3>🛠️ Proficient Languages</h3>
 <p align="center">
-  <a href="https://skillicons.dev">
-    <img src="https://skillicons.dev/icons?i=java,cpp,ts,cs,py" />
-  </a>
+  <img src="https://img.shields.io/badge/java-%23ED8B00.svg?style=for-the-badge&logo=openjdk&logoColor=white" alt="Java" />
+  <img src="https://img.shields.io/badge/c++-%2300599C.svg?style=for-the-badge&logo=c%2B%2B&logoColor=white" alt="C++" />
+  <img src="https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/c%23-%23239120.svg?style=for-the-badge&logo=c-sharp&logoColor=white" alt="C#" />
+  <img src="https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54" alt="Python" />
 </p>
   <br/>
   ✍️ Words to code by:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refreshes the `README.md` proficiency section visuals.
> 
> - Replace the `skillicons.dev` image block with shields.io badges for `Java`, `C++`, `TypeScript`, `C#`, and `Python`
> - Keep the surrounding section layout and content unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90269bee32954081c8fecedf82cb8b825964d908. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->